### PR TITLE
import theme after default reveal css

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,8 @@ import Highlight from 'reveal.js/plugin/highlight/highlight.esm.js';
 import Markdown from 'reveal.js/plugin/markdown/markdown.esm.js';
 import Notes from 'reveal.js/plugin/notes/notes.esm.js';
 
-import '@theme';
 import 'reveal.js/dist/reveal.css';
+import '@theme';
 
 const markdownFiles = import.meta.glob('slides/*.md', {
 	as: 'raw',


### PR DESCRIPTION
This is to allow for the theme CSS to be able to override items in the default styles when they have the same precedence 👍 