### PR TITLE
allow themes to be able to provide config for initialize

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,11 +36,24 @@ document.querySelector('.slides').innerHTML = sections.join('');
 
 const deck = new Reveal();
 
-deck.initialize({
+const defaultConfig = {
 	hash: true,
 	width: 1280,
 	height: 960,
 	margin: 0.1,
 	highlight: {},
 	plugins: [Markdown, Highlight, Notes],
-});
+};
+
+let themeConfig = {};
+
+try {
+	const findingConfig = import.meta.glob('@theme/config.json', {eager: true});
+	const [filename] = Object.keys(findingConfig);
+
+	if (filename) {
+		themeConfig = findingConfig[filename]
+	}
+} catch {}
+
+deck.initialize({...defaultConfig, ...themeConfig});


### PR DESCRIPTION
This allows a theme to provide a config.json to add to or override variables passed to initialise.

I know we discussed this before but I can't remember if we wanted to change the type of the config file or if you were ok with json being there 🤔 