### PR TITLE
add a default highlight theme to the css

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import Markdown from 'reveal.js/plugin/markdown/markdown.esm.js';
 import Notes from 'reveal.js/plugin/notes/notes.esm.js';
 
 import 'reveal.js/dist/reveal.css';
+import 'reveal.js/plugin/highlight/monokai.css'
 import '@theme';
 
 const markdownFiles = import.meta.glob('slides/*.md', {


### PR DESCRIPTION
It would be nice if we could figure out a way for a theme to provide this without needing to lock in versions of highlight or reveal... I know we discussed this already but I can't remember the exact conclusion of the direction we wanted to go 🤔 do you remember?